### PR TITLE
feat: add traditional to simplified chinese conversion support and strip enhanced LRC tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/huandu/go-sqlbuilder v1.39.1
 	github.com/jessevdk/go-flags v1.6.1
+	github.com/longbridgeapp/opencc v0.3.13
 	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/mozillazg/go-pinyin v0.20.0
 	github.com/pelletier/go-toml/v2 v2.2.3
@@ -18,5 +19,7 @@ require (
 require (
 	github.com/huandu/go-clone v1.7.3 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
+	github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d // indirect
+	github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d // indirect
 	golang.org/x/sys v0.27.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Endg4meZer0/go-mpris v1.0.5 h1:a3FUGD/h3tQAFlcl/YH4TVwtI/NVm4UJAGMEyaKai7I=
 github.com/Endg4meZer0/go-mpris v1.0.5/go.mod h1:eh//AAqSR5XF4G2mAKe9NrSp5sH8G6f3RnYzbupi8tU=
+github.com/adamzy/cedar-go v0.0.0-20170805034717-80a9c64b256d h1:ir/IFJU5xbja5UaBEQLjcvn7aAU01nqU/NUyOBEU+ew=
+github.com/adamzy/cedar-go v0.0.0-20170805034717-80a9c64b256d/go.mod h1:PRWNwWq0yifz6XDPZu48aSld8BWwBfr2JKB2bGWiEd4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,6 +19,15 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d h1:qSmEGTgjkESUX5kPMSGJ4pcBUtYVDdkNzMrjQyvRvp0=
+github.com/liuzl/cedar-go v0.0.0-20170805034717-80a9c64b256d/go.mod h1:x7SghIWwLVcJObXbjK7S2ENsT1cAcdJcPl7dRaSFog0=
+github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d h1:hTRDIpJ1FjS9ULJuEzu69n3qTgc18eI+ztw/pJv47hs=
+github.com/liuzl/da v0.0.0-20180704015230-14771aad5b1d/go.mod h1:7xD3p0XnHvJFQ3t/stEJd877CSIMkH/fACVWen5pYnc=
+github.com/longbridgeapp/opencc v0.3.13 h1:H8r4oXL4s+oR3gbBb4tW4D26jT+Mc5+znzwAnXsx4ao=
+github.com/longbridgeapp/opencc v0.3.13/go.mod h1:jRuKtq8eLA+cZUu75XgMvkB/hFSXJbZDmij0v29lNaY=
 github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
 github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mozillazg/go-pinyin v0.20.0 h1:BtR3DsxpApHfKReaPO1fCqF4pThRwH9uwvXzm+GnMFQ=
@@ -25,6 +36,7 @@ github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNH
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/srevinsaju/korean-romanizer-go v0.0.2 h1:Xc+GCkvVfqJrUB0j6s39qfakIn7T2X6Oz7P2EczJ3S4=
 github.com/srevinsaju/korean-romanizer-go v0.0.2/go.mod h1:dD9s180Mch0duPNbmRRaHVwJ8zbvdw8r3keT3IcLHYs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -35,7 +47,9 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/lyrics/configure.go
+++ b/internal/lyrics/configure.go
@@ -1,10 +1,31 @@
 package lyrics
 
 import (
+	"sync"
+
+	"github.com/longbridgeapp/opencc"
+
+	"lrcsnc/internal/pkg/global"
 	"lrcsnc/internal/pkg/log"
 	playerStructs "lrcsnc/internal/pkg/structs/player"
 	"lrcsnc/internal/romanization"
 )
+
+var (
+	t2s        *opencc.OpenCC
+	t2sOnce    sync.Once
+	t2sInitErr error
+)
+
+func getT2S() *opencc.OpenCC {
+	t2sOnce.Do(func() {
+		t2s, t2sInitErr = opencc.New("t2s")
+		if t2sInitErr != nil {
+			log.Warn("lyrics/configure", "Failed to initialize OpenCC: "+t2sInitErr.Error())
+		}
+	})
+	return t2s
+}
 
 // Configure sets up the lyrics data by applying necessary configurations.
 // It should be called after format decrypt and before the data is sent to
@@ -17,6 +38,18 @@ import (
 // No locking a mutex in THIS function.
 func Configure(lyricsData *playerStructs.LyricsData) {
 	log.Debug("lyrics/configure", "Starting configuring the received lyrics")
+
+	// Traditional to Simplified
+	if global.Config.C.Lyrics.T2S {
+		if t := getT2S(); t != nil {
+			log.Debug("lyrics/configure", "Applying Traditional to Simplified Chinese conversion")
+			for i := range lyricsData.Lyrics {
+				if converted, err := t.Convert(lyricsData.Lyrics[i].Text); err == nil {
+					lyricsData.Lyrics[i].Text = converted
+				}
+			}
+		}
+	}
 
 	// Romanization
 	log.Debug("lyrics/configure", "Applying romanization if enabled and necessary")

--- a/internal/lyrics/formats/lrc/lrc.go
+++ b/internal/lyrics/formats/lrc/lrc.go
@@ -10,6 +10,7 @@ import (
 )
 
 var timingRegexp = regexp.MustCompile(`(\[[0-9]{2}:[0-9]{2}.[0-9]{1,3}])+`)
+var subTimingRegexp = regexp.MustCompile(`(<[0-9]{2}:[0-9]{2}.[0-9]{1,3}>)+`)
 
 // ConvertPlain is pretty much self-explanatory.
 //
@@ -52,6 +53,7 @@ func ConvertSynced(data string) playerStructs.Lyrics {
 		for _, ts := range timings {
 			lyric = strings.Replace(lyric, ts, "", 1)
 		}
+		lyric = subTimingRegexp.ReplaceAllString(lyric, "")
 		lyric = strings.TrimSpace(lyric)
 
 		hasRepetitiveLyrics = hasRepetitiveLyrics || len(timings) > 1

--- a/internal/pkg/structs/config/lyrics/config.go
+++ b/internal/pkg/structs/config/lyrics/config.go
@@ -8,5 +8,6 @@ import (
 type Config struct {
 	Provider     types.LyricsProviderType `toml:"provider"`
 	TimingOffset float64                  `toml:"timing-offset"`
+	T2S          bool                     `toml:"t2s"`
 	Romanization romanization.Config      `toml:"romanization"`
 }


### PR DESCRIPTION
This commit adds a new configuration option `t2s = true` under `[lyrics]` to automatically convert Traditional Chinese lyrics into Simplified Chinese using opencc. It applies to both downloaded and cached lyrics.

Additionally, it fixes an issue where LrcLib enhanced LRC format (which includes sub-line word timestamps like `<00:00.00>`) was not being properly parsed and resulted in timestamps leaking into the output string.